### PR TITLE
FakePlugin-STEP3 Annotator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ intellij {
     version.set("2022.1.4")
     type.set("IC") // Target IDE Platform
 
-    plugins.set(listOf(/* Plugin Dependencies */))
+    plugins.set(listOf("java"))
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ intellij {
     version.set("2022.1.4")
     type.set("IC") // Target IDE Platform
 
-    plugins.set(listOf("java"))
+    plugins.set(listOf("java", "Kotlin"))
 }
 
 tasks {

--- a/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
+++ b/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
@@ -6,6 +6,8 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiImportStatement
+import com.intellij.psi.PsiPackageStatement
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtPackageDirective
 
@@ -19,12 +21,12 @@ class SimpleAnnotator : Annotator {
         val value = element.text ?: return
         val textRange = element.textRange
 
-        if (element is KtPackageDirective) {
+        if (element is KtPackageDirective || element is PsiPackageStatement) {
             holder.newAnnotation(HighlightSeverity.WARNING, "This is a package")
                 .range(textRange)
                 .highlightType(ProblemHighlightType.WEAK_WARNING)
                 .create()
-        } else if (element is KtImportDirective) {
+        } else if (element is KtImportDirective || element is PsiImportStatement) {
             holder.newAnnotation(HighlightSeverity.INFORMATION, "This is an import")
                 .range(textRange)
                 .highlightType(ProblemHighlightType.GENERIC_ERROR)

--- a/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
+++ b/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
@@ -1,0 +1,31 @@
+package org.sonar.fakeplugin.language
+
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.psi.PsiElement
+
+class SimpleAnnotator : Annotator {
+
+    companion object {
+        const val WORD_ANNOTATED = "SONAR"
+    }
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        val value = element.text ?: return
+
+        if (value != WORD_ANNOTATED) {
+            return
+        }
+
+        val textRange = element.textRange
+
+
+        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+            .range(textRange)
+            .textAttributes(DefaultLanguageHighlighterColors.KEYWORD)
+            .create()
+    }
+
+}

--- a/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
+++ b/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
@@ -6,7 +6,8 @@ import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.psi.PsiElement
-import com.intellij.psi.util.elementType
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtPackageDirective
 
 class SimpleAnnotator : Annotator {
 
@@ -17,14 +18,13 @@ class SimpleAnnotator : Annotator {
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         val value = element.text ?: return
         val textRange = element.textRange
-        val elementType = element.elementType.toString()
 
-        if (elementType == "PACKAGE_DIRECTIVE") {
+        if (element is KtPackageDirective) {
             holder.newAnnotation(HighlightSeverity.WARNING, "This is a package")
                 .range(textRange)
                 .highlightType(ProblemHighlightType.WEAK_WARNING)
                 .create()
-        } else if (elementType == "IMPORT_DIRECTIVE") {
+        } else if (element is KtImportDirective) {
             holder.newAnnotation(HighlightSeverity.INFORMATION, "This is an import")
                 .range(textRange)
                 .highlightType(ProblemHighlightType.GENERIC_ERROR)

--- a/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
+++ b/src/main/kotlin/org/sonar/fakeplugin/language/SimpleAnnotator.kt
@@ -1,10 +1,12 @@
 package org.sonar.fakeplugin.language
 
+import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.lang.annotation.Annotator
 import com.intellij.lang.annotation.HighlightSeverity
 import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
 
 class SimpleAnnotator : Annotator {
 
@@ -14,18 +16,26 @@ class SimpleAnnotator : Annotator {
 
     override fun annotate(element: PsiElement, holder: AnnotationHolder) {
         val value = element.text ?: return
-
-        if (value != WORD_ANNOTATED) {
-            return
-        }
-
         val textRange = element.textRange
+        val elementType = element.elementType.toString()
 
-
-        holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
-            .range(textRange)
-            .textAttributes(DefaultLanguageHighlighterColors.KEYWORD)
-            .create()
+        if (elementType == "PACKAGE_DIRECTIVE") {
+            holder.newAnnotation(HighlightSeverity.WARNING, "This is a package")
+                .range(textRange)
+                .highlightType(ProblemHighlightType.WEAK_WARNING)
+                .create()
+        } else if (elementType == "IMPORT_DIRECTIVE") {
+            holder.newAnnotation(HighlightSeverity.INFORMATION, "This is an import")
+                .range(textRange)
+                .highlightType(ProblemHighlightType.GENERIC_ERROR)
+                .tooltip("This is a tooltip")
+                .create()
+        } else if (value == WORD_ANNOTATED) {
+            holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .range(textRange)
+                .textAttributes(DefaultLanguageHighlighterColors.STATIC_FIELD)
+                .create()
+        }
     }
 
 }

--- a/src/main/kotlin/org/sonar/fakeplugin/language/SimpleJavaAnnotator.kt
+++ b/src/main/kotlin/org/sonar/fakeplugin/language/SimpleJavaAnnotator.kt
@@ -8,10 +8,8 @@ import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiImportStatement
 import com.intellij.psi.PsiPackageStatement
-import org.jetbrains.kotlin.psi.KtImportDirective
-import org.jetbrains.kotlin.psi.KtPackageDirective
 
-class SimpleAnnotator : Annotator {
+class SimpleJavaAnnotator : Annotator {
 
     companion object {
         const val WORD_ANNOTATED = "SONAR"
@@ -21,12 +19,12 @@ class SimpleAnnotator : Annotator {
         val value = element.text ?: return
         val textRange = element.textRange
 
-        if (element is KtPackageDirective || element is PsiPackageStatement) {
+        if (element is PsiPackageStatement) {
             holder.newAnnotation(HighlightSeverity.WARNING, "This is a package")
                 .range(textRange)
                 .highlightType(ProblemHighlightType.WEAK_WARNING)
                 .create()
-        } else if (element is KtImportDirective || element is PsiImportStatement) {
+        } else if (element is PsiImportStatement) {
             holder.newAnnotation(HighlightSeverity.INFORMATION, "This is an import")
                 .range(textRange)
                 .highlightType(ProblemHighlightType.GENERIC_ERROR)

--- a/src/main/kotlin/org/sonar/fakeplugin/language/SimpleKotlinAnnotator.kt
+++ b/src/main/kotlin/org/sonar/fakeplugin/language/SimpleKotlinAnnotator.kt
@@ -1,0 +1,41 @@
+package org.sonar.fakeplugin.language
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.Annotator
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.DefaultLanguageHighlighterColors
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtImportDirective
+import org.jetbrains.kotlin.psi.KtPackageDirective
+
+class SimpleKotlinAnnotator : Annotator {
+
+    companion object {
+        const val WORD_ANNOTATED = "SONAR"
+    }
+
+    override fun annotate(element: PsiElement, holder: AnnotationHolder) {
+        val value = element.text ?: return
+        val textRange = element.textRange
+
+        if (element is KtPackageDirective) {
+            holder.newAnnotation(HighlightSeverity.WARNING, "This is a package")
+                .range(textRange)
+                .highlightType(ProblemHighlightType.WEAK_WARNING)
+                .create()
+        } else if (element is KtImportDirective) {
+            holder.newAnnotation(HighlightSeverity.INFORMATION, "This is an import")
+                .range(textRange)
+                .highlightType(ProblemHighlightType.GENERIC_ERROR)
+                .tooltip("This is a tooltip")
+                .create()
+        } else if (value == WORD_ANNOTATED) {
+            holder.newSilentAnnotation(HighlightSeverity.INFORMATION)
+                .range(textRange)
+                .textAttributes(DefaultLanguageHighlighterColors.STATIC_FIELD)
+                .create()
+        }
+    }
+
+}

--- a/src/main/kotlin/org/sonar/fakeplugin/language/Toto.java
+++ b/src/main/kotlin/org/sonar/fakeplugin/language/Toto.java
@@ -1,0 +1,10 @@
+package org.sonar.fakeplugin.language;
+
+// Dummy class for testing annotator
+public class Toto {
+
+  public static void toto() {
+    System.out.println("SONAR");
+  }
+
+}

--- a/src/main/resources/META-INF/plugin-withKotlin.xml
+++ b/src/main/resources/META-INF/plugin-withKotlin.xml
@@ -1,0 +1,8 @@
+<!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
+<idea-plugin>
+  
+  <extensions defaultExtensionNs="com.intellij">
+    <annotator language="kotlin" implementationClass="org.sonar.fakeplugin.language.SimpleAnnotator"/>
+  </extensions>
+
+</idea-plugin>

--- a/src/main/resources/META-INF/plugin-withKotlin.xml
+++ b/src/main/resources/META-INF/plugin-withKotlin.xml
@@ -2,7 +2,7 @@
 <idea-plugin>
   
   <extensions defaultExtensionNs="com.intellij">
-    <annotator language="kotlin" implementationClass="org.sonar.fakeplugin.language.SimpleAnnotator"/>
+    <annotator language="kotlin" implementationClass="org.sonar.fakeplugin.language.SimpleKotlinAnnotator"/>
   </extensions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -18,6 +18,7 @@
   <!-- Product and plugin compatibility requirements.
        Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
   <depends>com.intellij.modules.platform</depends>
+  <depends>com.intellij.java</depends>
 
   <actions>
     <action id="FakePlugin.NotificationButton" class="org.sonar.fakeplugin.actions.NotificationButtonAction"
@@ -33,6 +34,7 @@
   
   <extensions defaultExtensionNs="com.intellij">
     <notificationGroup displayType="BALLOON" id="Hello World Notification"/>
+    <annotator language="kotlin" implementationClass="org.sonar.fakeplugin.language.SimpleAnnotator"/>
   </extensions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,7 +19,7 @@
        Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.java</depends>
-  <depends>org.jetbrains.kotlin</depends>
+  <depends optional="true" config-file="plugin-withKotlin.xml">org.jetbrains.kotlin</depends>
 
   <actions>
     <action id="FakePlugin.NotificationButton" class="org.sonar.fakeplugin.actions.NotificationButtonAction"
@@ -35,7 +35,7 @@
   
   <extensions defaultExtensionNs="com.intellij">
     <notificationGroup displayType="BALLOON" id="Hello World Notification"/>
-    <annotator language="kotlin" implementationClass="org.sonar.fakeplugin.language.SimpleAnnotator"/>
+    <annotator language="JAVA" implementationClass="org.sonar.fakeplugin.language.SimpleAnnotator"/>
   </extensions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -35,7 +35,7 @@
   
   <extensions defaultExtensionNs="com.intellij">
     <notificationGroup displayType="BALLOON" id="Hello World Notification"/>
-    <annotator language="JAVA" implementationClass="org.sonar.fakeplugin.language.SimpleAnnotator"/>
+    <annotator language="JAVA" implementationClass="org.sonar.fakeplugin.language.SimpleJavaAnnotator"/>
   </extensions>
 
 </idea-plugin>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -19,6 +19,7 @@
        Read more: https://plugins.jetbrains.com/docs/intellij/plugin-compatibility.html -->
   <depends>com.intellij.modules.platform</depends>
   <depends>com.intellij.java</depends>
+  <depends>org.jetbrains.kotlin</depends>
 
   <actions>
     <action id="FakePlugin.NotificationButton" class="org.sonar.fakeplugin.actions.NotificationButtonAction"


### PR DESCRIPTION
Add an extension point to annotate some ranges in the text editor (like a Linter). You can start simple, by annotating a fixed word (like SONAR). You can try to customize the annotation style, and change the style dynamically depending on the annotated content.